### PR TITLE
feat: assignable downstream PRs

### DIFF
--- a/pkg/apis/updatebot/v1alpha1/types.go
+++ b/pkg/apis/updatebot/v1alpha1/types.go
@@ -48,6 +48,12 @@ type Rule struct {
 	// SparseCheckout governs if sparse checkout is made of repository. Only possible with regex and go changes.
 	// Note: Not all git servers support this.
 	SparseCheckout bool `json:"sparseCheckout,omitempty"`
+
+	// PullRequestAssignees
+	PullRequestAssignees []string `json:"pullRequestAssignees,omitempty"`
+
+	// AssignAuthorToPullRequests governs if downstream pull requests are automatically assigned to the upstream author
+	AssignAuthorToPullRequests bool `json:"assignAuthorToPullRequests,omitempty"`
 }
 
 // Change the kind of change to make on a repository

--- a/pkg/cmd/pr/pr_test.go
+++ b/pkg/cmd/pr/pr_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jenkins-x/jx-helpers/v3/pkg/stringhelpers"
 
 	"github.com/jenkins-x-plugins/jx-updatebot/pkg/cmd/pr"
+	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/cmdrunner"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/cmdrunner/fakerunner"
@@ -20,7 +21,7 @@ import (
 func TestCreate(t *testing.T) {
 	ev := os.Getenv("JX_EXCLUDE_TEST")
 	if ev == "" {
-		ev = "go"
+		ev = "go,assignauthor"
 	}
 	excludeTests := strings.Split(ev, ",")
 	runner := &fakerunner.FakeRunner{
@@ -78,10 +79,78 @@ func TestCreate(t *testing.T) {
 			require.Len(t, fakeData.PullRequests, 1, "should have 1 Pull Request created for %s", name)
 		}
 
-		for n, pr := range fakeData.PullRequests {
-			t.Logf("test %s created PR #%d with title: %s\n", name, n, pr.Title)
-			t.Logf("body: %s\n\n", pr.Body)
+		for n, pullRequest := range fakeData.PullRequests {
+			t.Logf("test %s created PR #%d with title: %s\n", name, n, pullRequest.Title)
+			t.Logf("body: %s\n\n", pullRequest.Body)
 		}
 
+	}
+}
+
+func TestAssignAuthorToCommit(t *testing.T) {
+	fileNames, err := os.ReadDir("test_data")
+	assert.NoError(t, err)
+
+	for _, f := range fileNames {
+		if !f.IsDir() || f.Name() != "assignauthor" {
+			continue
+		}
+
+		t.Logf("Running test for %s\n", f.Name())
+
+		dir := filepath.Join("test_data", f.Name())
+		fakeScmClient, fakeData := fake.NewDefault()
+
+		// Prepopulate fake data
+		fakeData.Commits["dummy-sha"] = &scm.Commit{
+			Sha: "dummy-sha",
+			Author: scm.Signature{
+				Login: "test-author",
+			},
+		}
+		fakeData.PullRequests[1] = &scm.PullRequest{
+			Number: 1,
+			Title:  "Test PR",
+		}
+
+		fakeData.AssigneesAdded = []string{}
+
+		runner := &fakerunner.FakeRunner{
+			CommandRunner: func(c *cmdrunner.Command) (string, error) {
+				if c.Name == "git" && len(c.Args) > 0 && c.Args[0] == "push" {
+					t.Logf("faking command %s in dir %s\n", c.CLI(), c.Dir)
+					return "", nil
+				}
+				return cmdrunner.DefaultCommandRunner(c)
+			},
+		}
+
+		// Configure the Options object
+		_, o := pr.NewCmdPullRequest()
+		o.Dir = dir
+		o.CommandRunner = runner.Run
+		o.ScmClient = fakeScmClient
+		o.ScmClientFactory.ScmClient = fakeScmClient
+		o.ScmClientFactory.NoWriteGitCredentialsFile = true
+		o.Version = "1.2.3"
+		o.PipelineCommitSha = "dummy-sha"
+		o.EnvironmentPullRequestOptions.ScmClientFactory.GitServerURL = "https://github.com"
+		o.EnvironmentPullRequestOptions.ScmClientFactory.GitToken = "dummytoken"
+		o.EnvironmentPullRequestOptions.ScmClientFactory.GitUsername = "dummyuser"
+
+		// Run the command
+		err = o.Run()
+		require.NoError(t, err, "failed to run command for test %s", f.Name())
+
+		// Validate the assignments
+		expectedAssignees := []string{"foo", "bar", "test-author"}
+		actualAssignees := []string{}
+		for _, assignee := range fakeData.AssigneesAdded {
+			parts := strings.Split(assignee, ":")
+			actualAssignees = append(actualAssignees, parts[1])
+		}
+
+		assert.ElementsMatch(t, expectedAssignees, actualAssignees, "PR should include all specified assignees")
+		t.Logf("PR created successfully with assignees: %v\n", actualAssignees)
 	}
 }

--- a/pkg/cmd/pr/test_data/assignauthor/.jx/updatebot.yaml
+++ b/pkg/cmd/pr/test_data/assignauthor/.jx/updatebot.yaml
@@ -1,0 +1,19 @@
+apiVersion: updatebot.jenkins-x.io/v1alpha1
+kind: UpdateConfig
+spec:
+  rules:
+  - urls:
+    - https://github.com/jx3-gitops-repositories/jx3-kubernetes
+    changes:
+    - command:
+        name: sh
+        args:
+        - -c
+        - "echo $CHEESE > cheese.txt"
+        env:
+        - name: CHEESE
+          value: Edam
+    pullRequestAssignees:
+      - foo
+      - bar
+    assignAuthorToPullRequests: true


### PR DESCRIPTION
Adds the ability to assign a list of users to any downstream PRs generated by updatebot. Can also assign the author of the upstream commit by setting `spec.rules.assignAuthorToPullRequests: true` within the updatebot yaml.

Example: `pkg/cmd/pr/test_data/assignauthor/.jx/updatebot.yaml`

Only tested for GitHub. Also assumes author can be assigned to other dependent repositories.