### PR TITLE
fix: empty pr causes error with assignusers

### DIFF
--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -414,10 +414,10 @@ func (o *Options) ProcessAndCreatePullRequests(rule *v1alpha1.Rule, baseBranch s
 		}
 		if pr != nil {
 			o.AddPullRequest(pr)
-		}
-		err = o.AssignUsersToPullRequestIssue(rule, pr, ruleURL, o.PipelineRepoURL, o.PipelineCommitSha, o.GitKind)
-		if err != nil {
-			return fmt.Errorf("failed to assign users to PR: %w", err)
+			err = o.AssignUsersToPullRequestIssue(rule, pr, ruleURL, o.PipelineRepoURL, o.PipelineCommitSha, o.GitKind)
+			if err != nil {
+				return fmt.Errorf("failed to assign users to PR: %w", err)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
### Changes
Move AssignUsersToPullRequestIssue into when pr != nil catch

### Context
If no PR is created (no changes found) process errors with - runtime error: invalid memory address or nil pointer dereference

Remaining URLs are not processed